### PR TITLE
Github helper for authorised requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
+GITHUB_TOKEN=github_pat___check_docs_above

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  DENO_DIR: ./cache
+  DENO_DIR: .cache
 
 jobs:
   health:

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,0 +1,11 @@
+import { load } from 'https://deno.land/std@0.180.0/dotenv/mod.ts';
+
+const GITHUB_TOKEN = Deno.env.get('GITHUB_TOKEN') ??
+	(await load()).GITHUB_TOKEN;
+
+/** Headers to authenticate Github requests */
+export const headers: HeadersInit = GITHUB_TOKEN !== undefined
+	? {
+		Authorization: `Bearer ${GITHUB_TOKEN}`,
+	}
+	: {};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add method to authorise Github requests with personal access tokens.

## How to test

We would need a use case for this.

## How can we measure success?

Not much value yet

## Have we considered potential risks?

Users should be careful with their personal access tokens.

## Images

N/A

## Accessibility

N/A