### PR TITLE
fix: handle `null`s in OJ score

### DIFF
--- a/src/bigquery_score/score.js
+++ b/src/bigquery_score/score.js
@@ -30,4 +30,6 @@ export const is_metric = (metric) => metric in metrics;
  * @param {number} value
  */
 export const get_web_vitals_score = (metric, value) =>
-	getLogNormalScore(metrics[metric], value) * 100;
+	is_metric(metric) && typeof value === 'number'
+		? getLogNormalScore(metrics[metric], value) * 100
+		: undefined;

--- a/src/bigquery_score/score.test.ts
+++ b/src/bigquery_score/score.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from 'https://deno.land/std@0.180.0/testing/asserts.ts';
 
-import { get_web_vitals_score, is_metric } from './score.js';
+import { get_web_vitals_score } from './score.js';
 
 Deno.test('FID', () => {
 	assertEquals(get_web_vitals_score('fid', 0), 100);
@@ -27,5 +27,14 @@ Deno.test('TTFB', () => {
 });
 
 Deno.test('Returns undefined for invalid metrics', () => {
-	assertEquals(is_metric('INCORRECT'), false);
+	// @ts-expect-error -- we’re checking usage outside TS
+	assertEquals(get_web_vitals_score('INCORRECT', 100), undefined);
+	// @ts-expect-error -- we’re checking usage outside TS
+	assertEquals(get_web_vitals_score('fid', undefined), undefined);
+	// @ts-expect-error -- we’re checking usage outside TS
+	assertEquals(get_web_vitals_score('ttfb', null), undefined);
+	// @ts-expect-error -- we’re checking usage outside TS
+	assertEquals(get_web_vitals_score('ttfb', 'null'), undefined);
+	// @ts-expect-error -- we’re checking usage outside TS
+	assertEquals(get_web_vitals_score('ttfb', ''), undefined);
 });

--- a/src/bigquery_score/scripts/bundle.ts
+++ b/src/bigquery_score/scripts/bundle.ts
@@ -21,7 +21,6 @@ await Deno.writeTextFile(
 		'// -- bundle output : end -- //',
 		'',
 		'// return the value',
-		'if(!is_metric(metric)) return undefined;',
 		'return get_web_vitals_score(metric, value);',
 	].join('\n'),
 );


### PR DESCRIPTION
## What does this change?

Handle cases where metrics are undefined

## How to test

```sql
-- built from https://github.com/guardian/open-journalism/tree/main/src/bigquery_score
CREATE TEMP FUNCTION get_web_vitals_score(metric STRING, value FLOAT64)
RETURNS NUMERIC
LANGUAGE js
AS r"""
// @ts-nocheck -- bundle output : start -- //
const MIN_PASSING_SCORE = 0.90000000000000002220446049250313080847263336181640625;const MAX_AVERAGE_SCORE = 0.899999999999999911182158029987476766109466552734375;const MIN_AVERAGE_SCORE = 0.5;const MAX_FAILING_SCORE = 0.499999999999999944488848768742172978818416595458984375;function erf(x) { const sign = Math.sign(x); x = Math.abs(x); const a2 = -0.284496736; const a4 = -1.453152027; const t = 1 / (1 + 0.3275911 * x); const y = t * (0.254829592 + t * (a2 + t * (1.421413741 + t * (a4 + t * 1.061405429)))); return sign * (1 - y * Math.exp(-x * x));}function getLogNormalScore({ median , p10 }, value) { if (median <= 0) throw new Error('median must be greater than zero'); if (p10 <= 0) throw new Error('p10 must be greater than zero'); if (p10 >= median) throw new Error('p10 must be less than the median'); if (value <= 0) return 1; const xRatio = Math.max(Number.MIN_VALUE, value / median); const xLogRatio = Math.log(xRatio); const p10Ratio = Math.max(Number.MIN_VALUE, p10 / median); const p10LogRatio = -Math.log(p10Ratio); const standardizedX = xLogRatio * 0.9061938024368232 / p10LogRatio; const complementaryPercentile = (1 - erf(standardizedX)) / 2; let score; if (value <= p10) { score = Math.max(MIN_PASSING_SCORE, Math.min(1, complementaryPercentile)); } else if (value <= median) { score = Math.max(MIN_AVERAGE_SCORE, Math.min(MAX_AVERAGE_SCORE, complementaryPercentile)); } else { score = Math.max(0, Math.min(MAX_FAILING_SCORE, complementaryPercentile)); } return score;}const metrics = { cls: { p10: 0.1, median: 0.25 }, fid: { p10: 100, median: 300 }, lcp: { p10: 2500, median: 4000 }, fcp: { p10: 1800, median: 3000 }, ttfb: { p10: 800, median: 1800 }};const is_metric = (metric)=>metric in metrics;const get_web_vitals_score = (metric, value)=>is_metric(metric) && typeof value === 'number' ? getLogNormalScore(metrics[metric], value) * 100 : undefined;
// -- bundle output : end -- //

// return the value
return get_web_vitals_score(metric, value);
""";


-- The actual query!
SELECT
    get_web_vitals_score('nothing', 10)
  , get_web_vitals_score('cls', null)
  , get_web_vitals_score('cls', 0.24)
  , get_web_vitals_score('cls', 0.08)
```

## How can we measure success?

More reliable score

## Have we considered potential risks?

N/A

## Images

N/A

## Accessibility

N/A